### PR TITLE
Align experience icons to top

### DIFF
--- a/src/subPages/Experience.tsx
+++ b/src/subPages/Experience.tsx
@@ -8,75 +8,79 @@ const Experience = () => {
     <div className="Experience" id="54356345">
       <h2 className="titleProject ExperienceTitle">Experience</h2>
       <hr className="Break" />
-      <div className="employment">
-        <img className="logo" src={kpmgLogo} alt="KPMG" />
-        <div className="employmentDetails">
-          <h3 className="SubTitle">KPMG - Software Engineer</h3>
-          <p className="Date">September 2019 - October 2024</p>
-          <p className="Text">
-            Completed my Apprenticeship at KPMG as a Software Engineer.
-            Throughout my employment here, I've worked in a variety of areas in
-            web development including:
-          </p>
-          <h3 className="SubTitle">Highlights</h3>
-          <ul className="Highlights">
-            <li>
-              Designed, Developed and maintained multiple ReactJS, NodeJS and
-              Flask applications, this included things like UI Design,
-              architectural planning, Frontend + Backend Development, Unit test
-              creation, Application Deployment, CI/CD integrations using Github
-              Actions.
-            </li>
-            <li>
-              Migrated legacy backend systems to modern web technologies,
-              reducing server load by roughly 20% and increasing security.
-            </li>
-            <li>
-              Mentored junior developers and apprentices, contributing to team
-              growth and improved productivity.
-            </li>
-            <li>
-              Designed and implemented a backend that processed and
-              reconstructed huge amounts of JSON data (Gbs/second).
-            </li>
-            <li>
-              Adapted a key piece of in-house software to be used within our
-              CI/CD pipeline, previously it could only be run manually.
-            </li>
-          </ul>
+      <div className="experienceSection">
+        <div className="experienceCard">
+          <img className="logo" src={kpmgLogo} alt="KPMG" />
+          <div className="experienceDetails">
+            <h3 className="SubTitle">KPMG - Software Engineer</h3>
+            <p className="Date">September 2019 - October 2024</p>
+            <p className="Text">
+              Completed my Apprenticeship at KPMG as a Software Engineer.
+              Throughout my employment here, I've worked in a variety of areas in
+              web development including:
+            </p>
+            <h3 className="SubTitle">Highlights</h3>
+            <ul className="Highlights">
+              <li>
+                Designed, Developed and maintained multiple ReactJS, NodeJS and
+                Flask applications, this included things like UI Design,
+                architectural planning, Frontend + Backend Development, Unit test
+                creation, Application Deployment, CI/CD integrations using Github
+                Actions.
+              </li>
+              <li>
+                Migrated legacy backend systems to modern web technologies,
+                reducing server load by roughly 20% and increasing security.
+              </li>
+              <li>
+                Mentored junior developers and apprentices, contributing to team
+                growth and improved productivity.
+              </li>
+              <li>
+                Designed and implemented a backend that processed and
+                reconstructed huge amounts of JSON data (Gbs/second).
+              </li>
+              <li>
+                Adapted a key piece of in-house software to be used within our
+                CI/CD pipeline, previously it could only be run manually.
+              </li>
+            </ul>
+          </div>
         </div>
       </div>
       <hr className="Break" />
       <h2 className="titleProject ExperienceTitle">Qualifications</h2>
       <hr className="Break" />
-      <div className="qualification">
-        <img
-          className="logo"
-          src={queenMaryLogo}
-          alt="Queen Mary University of London"
-        />
-        <div className="qualificationDetails">
-          <h3 className="SubTitle">Queen Mary University of London</h3>
-          <p className="Date">
-            Bachelor of Science in Digital and Technology Solutions (Software
-            Engineer), 2019 - 2024
-          </p>
-          <p className="Text">
-            Completed an undergraduate degree in Computer Science, gaining a
-            strong foundation in software development, algorithms,
-            data-sctructures, deep learning and web technologies.
-          </p>
-          <h3 className="SubTitle">Key Achievements</h3>
-          <ul className="Highlights">
-            <li>Graduated with First-Class Honours.</li>
-            <li>
-              For my final year project I developed a accessibility evaluation
-              tool for WebPages that tells developers how to align them with the
-              WCAG guidelines. This used technologies such as Puppeteer and Axe
-              Core and can be deployed in a CI/CD pipeline or be used
-              standalone.{" "}
-            </li>
-          </ul>
+      <div className="experienceSection">
+        <div className="experienceCard">
+          <img
+            className="logo"
+            src={queenMaryLogo}
+            alt="Queen Mary University of London"
+          />
+          <div className="experienceDetails">
+            <h3 className="SubTitle">Queen Mary University of London</h3>
+            <p className="Date">
+              Bachelor of Science in Digital and Technology Solutions (Software
+              Engineer), 2019 - 2024
+            </p>
+            <p className="Text">
+              Completed an undergraduate degree in Computer Science, gaining a
+              strong foundation in software development, algorithms,
+              data-sctructures, deep learning and web technologies.
+            </p>
+            <h3 className="SubTitle">Key Achievements</h3>
+            <ul className="Highlights">
+              <li>Graduated with First-Class Honours.</li>
+              <li>
+                For my final year project I developed a accessibility evaluation
+                tool for WebPages that tells developers how to align them with the
+                WCAG guidelines. This used technologies such as Puppeteer and Axe
+                Core and can be deployed in a CI/CD pipeline or be used
+                standalone.
+              </li>
+            </ul>
+          </div>
         </div>
       </div>
     </div>

--- a/src/subPages/MainIntro.tsx
+++ b/src/subPages/MainIntro.tsx
@@ -30,7 +30,7 @@ const MainIntro = () => {
             <Cursor />
           </p>
         </div>
-        <hr className="Break" />
+        <hr className="BreakIntro" />
         <div className="ButtonHolder">
           <Button
             text={"Experience"}
@@ -48,7 +48,7 @@ const MainIntro = () => {
             onClick={() => handleClickScroll("AboutSubPage")}
           />
         </div>
-        <hr className="Break" />
+        <hr className="BreakIntro" />
         <div className="TagHolder">
           <Tag text={"Typescript"} background={"#007ACC"} color={"#fffaed"} />
           <Tag text={"Javascript"} background={"#f7df1e"} />

--- a/src/subPages/Projects.tsx
+++ b/src/subPages/Projects.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import "./css/Projects.css";
 import AHC from "../images/icons/AHC.png";
 import AHC_Logo from "../images/AHC_Logo.png";
@@ -6,29 +6,13 @@ import Tag from "../components/Tag";
 import Button from "../components/Button";
 
 const Projects = () => {
-  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-
-  const handleResize = () => {
-    setWindowWidth(window.innerWidth);
-  };
-
-  useEffect(() => {
-    // Listen for resize events
-    window.addEventListener("resize", handleResize);
-
-    // Cleanup the event listener on component unmount
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, []);
-
   return (
     <div className="Projects">
       <p className="titleProject">Projects</p>
       <hr className="Break" />
-      <div style={{ display: "flex" }}>
-        {windowWidth > 1350 && (
-          <div className="logoHolder">
+      <div className="projectSection">
+        <div className="projectCard">
+          <div className="projectMedia">
             <img
               src={AHC}
               alt="AutoHistoryCheck Icon"
@@ -48,14 +32,12 @@ const Projects = () => {
               />
             </a>
           </div>
-        )}
-        <div className="projectDescriptionHolder">
-          <img
-            className="projectTitle"
-            src={AHC_Logo}
-            alt="AutoHistoryCheck Logo"
-          />
-          <div className="reverser">
+          <div className="projectDetails">
+            <img
+              className="projectTitle"
+              src={AHC_Logo}
+              alt="AutoHistoryCheck Logo"
+            />
             <div className="TagProjectHolder">
               <Tag text={"Javascript"} background={"#f7df1e"} />
               <Tag
@@ -86,23 +68,6 @@ const Projects = () => {
               and uses CloudFlare for DNS and SSL.
             </p>
           </div>
-          {windowWidth < 1350 && (
-            <div className="logoHolder">
-              <a
-                href="https://autohistorycheck.co.uk/"
-                target="_blank"
-                rel="noreferrer"
-                className="quickLink"
-              >
-                <Button
-                  className="linkButton linkButtonMobile"
-                  text={"Visit AHC ->"}
-                  background={"#ffb300"}
-                  onClick={() => console.log("bye bye")}
-                />
-              </a>
-            </div>
-          )}
         </div>
       </div>
       <hr className="Break" />

--- a/src/subPages/css/Experience.css
+++ b/src/subPages/css/Experience.css
@@ -1,105 +1,135 @@
 .Experience {
   color: #fffaed;
-  padding: 20px;
-  border-radius: 8px;
-  max-width: 1200px;
   margin: auto;
+  margin-top: 2vh;
+  padding-bottom: 30vh;
+  width: 90%;
+  max-width: 1350px;
   font-family: "Roboto Mono", monospace;
-  background-color: #2c3e50;
-  margin-top: 10vh;
-  margin-bottom: 35vh;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
 }
 
 .Break {
   border: 0;
   height: 1px;
-  background: #fffaed;
+  background: rgba(255, 250, 237, 0.4);
   margin: 20px 0;
 }
 
-.employment,
-.qualification {
+.Experience .Break {
+  margin: 40px 0;
+}
+
+.experienceSection {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.experienceCard {
   display: flex;
   align-items: flex-start;
-  background-color: #34495e;
-  padding: 20px;
-  border-radius: 8px;
-  margin-bottom: 20px;
-  flex-wrap: wrap;
+  gap: 32px;
+  background: rgba(22, 21, 25, 0.85);
+  border: 1px solid rgba(255, 250, 237, 0.15);
+  border-radius: 24px;
+  padding: 32px;
+  backdrop-filter: blur(6px);
+  box-shadow: 0 18px 45px rgba(9, 4, 32, 0.35);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.experienceCard:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 26px 60px rgba(9, 4, 32, 0.45);
 }
 
 .logo {
-  width: 80px;
-  height: 80px;
-  margin-right: 20px;
-  border-radius: 8px;
-  border: 2px solid #fffaed;
+  flex-shrink: 0;
+  width: 120px;
+  height: 120px;
+  border-radius: 20px;
+  border: 2px solid rgba(255, 250, 237, 0.6);
+  object-fit: cover;
+  background: rgba(14, 13, 16, 0.65);
+  padding: 8px;
 }
 
-.employmentDetails,
-.qualificationDetails {
+.experienceDetails {
+  flex: 1 1 0;
   max-width: 1000px;
 }
 
 .SubTitle {
   font-size: 24px;
-  font-weight: bold;
+  font-weight: 700;
   margin: 0;
-  color: #fffaed;
 }
 
 .Date {
   font-size: 16px;
-  color: #ecf0f1;
-  margin: 5px 0 15px;
+  color: rgba(255, 250, 237, 0.75);
+  margin: 8px 0 18px;
 }
 
 .Text {
   font-size: 16px;
-  line-height: 1.6;
-  margin: 10px 0;
+  line-height: 1.7;
+  margin: 10px 0 18px;
+  color: rgba(255, 250, 237, 0.9);
 }
 
 .Highlights {
-  margin: 10px 0 0 20px;
-  padding: 0;
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 12px;
 }
 
 .Highlights li {
-  margin-bottom: 10px;
   font-size: 16px;
-}
-
-.titleProjectNoBreak {
-  text-align: center;
-  font-family: "Roboto Mono", monospace;
-  font-weight: 1000;
+  line-height: 1.6;
+  color: rgba(255, 250, 237, 0.9);
 }
 
 .ExperienceTitle {
-  margin-top: 0;
-  margin-bottom: 0;
+  margin: 0;
   padding-bottom: 0;
 }
 
-/* Media Queries for Mobile */
-@media (max-width: 768px) {
-  .Experience {
-    padding: 20px 10px;
-    background-color: #ffffff00;
-  }
-
-  .employment,
-  .qualification {
+@media (max-width: 1024px) {
+  .experienceCard {
     flex-direction: column;
     align-items: center;
     text-align: center;
   }
 
-  .employmentDetails,
-  .qualificationDetails {
-    max-width: 100%;
+  .experienceDetails {
     text-align: center;
+  }
+
+  .Highlights {
+    padding-left: 0;
+    list-style-position: inside;
+  }
+
+  .logo {
+    width: 100px;
+    height: 100px;
+  }
+}
+
+@media (max-width: 600px) {
+  .Experience {
+    width: 92%;
+    gap: 32px;
+  }
+
+  .experienceCard {
+    padding: 24px;
+    gap: 20px;
   }
 
   .SubTitle {
@@ -111,26 +141,5 @@
   .Highlights li {
     font-size: 14px;
   }
-
-  .Highlights {
-    list-style-type: none;
-    margin: 10px 0 0 0;
-  }
-
-  .logo {
-    margin-bottom: 20px;
-    margin-right: 0px;
-  }
 }
 
-@media (min-width: 769px) and (max-width: 1200px) {
-  .employment,
-  .qualification {
-    flex-direction: row;
-  }
-
-  .employmentDetails,
-  .qualificationDetails {
-    max-width: calc(100% - 120px); /* Adjust the max width to avoid wrapping */
-  }
-}

--- a/src/subPages/css/MainIntro.css
+++ b/src/subPages/css/MainIntro.css
@@ -24,6 +24,13 @@
   margin-bottom: 10px;
 }
 
+.BreakIntro {
+  border: 0;
+  height: 1px;
+  background: rgba(255, 250, 237, 0.4);
+  margin: 8px 0;
+}
+
 .TagHolder {
   display: flex;
   flex-wrap: wrap;

--- a/src/subPages/css/Projects.css
+++ b/src/subPages/css/Projects.css
@@ -1,101 +1,138 @@
 .Projects {
   color: #fffaed;
-  padding-top: 0px;
   margin: auto;
   max-width: 1350px;
   width: 90%;
   margin-top: 2vh;
   padding-bottom: 30vh;
+  font-family: "Roboto Mono", monospace;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
 }
 
 .titleProject {
   text-align: center;
-  padding-bottom: 50px;
-  font-family: "Roboto Mono", monospace;
   font-weight: 1000;
+  margin: 0;
 }
 
-.noBottom {
-  padding-bottom: 0px;
-  margin-bottom: 0px;
+.projectSection {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 }
 
-.ButtonWrapper {
-  float: right;
-  margin-top: 10px;
+.projectCard {
+  display: flex;
+  align-items: center;
+  gap: 32px;
+  background: rgba(22, 21, 25, 0.85);
+  border: 1px solid rgba(255, 250, 237, 0.15);
+  border-radius: 24px;
+  padding: 32px;
+  backdrop-filter: blur(6px);
+  box-shadow: 0 18px 45px rgba(9, 4, 32, 0.35);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.projectCard:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 26px 60px rgba(9, 4, 32, 0.45);
+}
+
+.projectMedia {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  flex-shrink: 0;
 }
 
 .projectLogo {
-  max-width: 240px;
-  max-height: 240px;
-  margin-right: 20px;
-  border-radius: 8px;
-  margin-top: 10px;
-  background-color: #161519;
-  padding: 20px;
-  border: 2px solid #fffaed;
+  width: 150px;
+  height: 150px;
+  border-radius: 20px;
+  border: 2px solid rgba(255, 250, 237, 0.6);
+  object-fit: contain;
+  background: rgba(14, 13, 16, 0.65);
+  padding: 16px;
+}
+
+.projectDetails {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
 }
 
 .projectTitle {
-  max-width: 1080px;
-  width: 90vw;
-}
-
-.projectText {
-  max-width: 1000px;
-  margin-left: 20px;
-  margin-right: 20px;
-
-}
-
-.projectDescriptionHolder{
-  justify-content: center;
+  width: min(100%, 420px);
 }
 
 .TagProjectHolder {
   display: flex;
   flex-wrap: wrap;
-  margin-left: 20px;
-  margin-right: 20px;
-  margin-bottom: 5px;
-  margin-top: -6px;
+  gap: 10px;
 }
 
-.quickLink :hover{
-  cursor: pointer;
+.projectText {
+  font-size: 16px;
+  line-height: 1.7;
+  color: rgba(255, 250, 237, 0.9);
+  margin: 0;
+}
+
+.quickLink {
+  width: 100%;
+  text-decoration: none;
 }
 
 .linkButton {
-  width: 284px;
+  width: 220px;
+  max-width: 100%;
 }
 
-.logoHolder{
-  width: 300px;
-}
-
-.reverser{
-  display: flex;
-  flex-direction: column;
-}
-
-
-@media (max-width: 1350px) {
-
-  .linkButtonMobile {
-    width: calc(90vw - 40px);
-    margin-left: 20px;
-    margin-right: 20px;
-    margin-top: 15px;
+@media (max-width: 1024px) {
+  .projectCard {
+    flex-direction: column;
+    text-align: center;
   }
-}
 
-@media (max-width: 762px) {
-  .reverser{
-    flex-direction: column-reverse;
+  .projectDetails {
+    align-items: center;
   }
 
   .TagProjectHolder {
-    margin-top: 25px;
-    margin-bottom: 0px;
+    justify-content: center;
+  }
+
+  .projectTitle {
+    width: min(100%, 480px);
+  }
+
+  .linkButton {
+    width: 100%;
+  }
+}
+
+@media (max-width: 600px) {
+  .Projects {
+    gap: 32px;
+  }
+
+  .projectCard {
+    padding: 24px;
+    gap: 20px;
+  }
+
+  .projectLogo {
+    width: 120px;
+    height: 120px;
+    padding: 12px;
+  }
+
+  .projectText {
+    font-size: 14px;
   }
 }


### PR DESCRIPTION
## Summary
- adjust the experience cards to align their logos to the top so the imagery sits at the section headers
- restore centered stacking on smaller screens so the mobile layout remains balanced

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d42fe1fd9c832d9200507582b89c2e